### PR TITLE
Add FWUP_IMAGE_DEPENDS for do_image_* dependencies

### DIFF
--- a/README
+++ b/README
@@ -7,12 +7,9 @@ Dependencies
 
   URI: https://github.com/openembedded/meta-openembedded.git
   layers: meta-oe
-  branch: kirkstone
+  branch: master
 
   URI: https://github.com/meta-erlang/meta-erlang
-  branch: kirkstone
-
-  URI: https://github.com/fwup-home/meta-fwup
   branch: master
 
 Table of Contents
@@ -37,3 +34,7 @@ The `fwup` and `fwup-img` `IMAGE_FSTYPES` will look for a fwup configuration
 file in `(my-layer)/conf/peridio` directory with the name `${MACHINENAME}.fwup.conf`.
 You can override this by setting `FWUP_FILE`. More information about fwup format
 can be found at [github.com/fwup-home](https://github.com/fwup-home/fwup)
+
+The `fwup` and `fwup-img` `do_image_` functions will need to execute after the other image
+dependencies have been deployed. To handle this, you can specify what deployed image typed
+you your fwup conf may depend on by appending to the `FWUP_IMAGE_DEPENDS` variable in your config.

--- a/classes/image_types_fwup.bbclass
+++ b/classes/image_types_fwup.bbclass
@@ -88,6 +88,7 @@ FWUP_VARS ?= " \
 "
 
 FWUP_EXTRA_VARS ?= ""
+FWUP_IMAGE_DEPENDS ?= "squashfs"
 
 FWUP_FILE ??= "${MACHINE}.fwup.conf"
 FWUP_SEARCH_PATH ?= "${@':'.join('%s/conf/peridio' % p for p in '${BBPATH}'.split(':'))}"
@@ -131,8 +132,7 @@ do_write_fwup_conf[file-checksums] += "${FWUP_FILE_CHECKSUM}"
 do_image_fwup[recrdeptask] += "do_deploy"
 do_image_fwup_img[recrdeptask] += "do_deploy"
 do_image_fwup[deptask] += "do_image_complete"
-do_image_fwup[recrdeptask] += "${@' '.join('do_image_%s' % r for r in ('squashfs', 'ext4', 'tar'))}"
-
+do_image_fwup[recrdeptask] += "${@' '.join('do_image_%s' % r for r in '${FWUP_IMAGE_DEPENDS}'.split())}"
 
 do_image_fwup[depends] += "${@' '.join('%s-native:do_populate_sysroot' % r for r in ('parted', 'gptfdisk', 'dosfstools', 'mtools'))}"
 do_image_fwup_img[depends] += "${@' '.join('%s-native:do_populate_sysroot' % r for r in ('parted', 'gptfdisk', 'dosfstools', 'mtools'))}"


### PR DESCRIPTION
Fixes a race condition with the execution order of the `do_image_fwup` image task and any other `do_image_*` task deployments which the fwup configuration would depend on. This cannot be inferred from the `IMAGE_FSTYPES` variable because task dependencies are evaluated before late expansion of additional `IMAGE_FSTYPES` from recipe parsing.