### PR TITLE
peridiod: bump to 2.5.0

### DIFF
--- a/recipes-peridio/peridiod/peridiod.inc
+++ b/recipes-peridio/peridiod/peridiod.inc
@@ -19,7 +19,7 @@ inherit systemd
 SYSTEMD_AUTO_ENABLE = "enable"
 SYSTEMD_SERVICE:${PN} = "peridiod.service"
 
-RDEPENDS:${PN} += "socat"
+RDEPENDS:${PN} += "socat wireguard-tools iproute2-ss iptables"
 
 FILES:${PN} += " \
   ${systemd_unitdir}/system/peridiod.service \
@@ -36,6 +36,10 @@ do_install:append() {
   install -d ${D}/${systemd_unitdir}/system
   install -d ${D}/${sysconfdir}/peridiod
 
+  archive=$(find ${erlang_release} -name "*.gz")
+  bbnote "Removing archive from release directory: ${archive}"
+  rm -f ${archive}
+
   # systemd
   if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
     install -m 0644 ${WORKDIR}/peridiod.service \
@@ -50,7 +54,6 @@ do_install:append() {
       ${D}${sysconfdir}/profile.d/peridiod.sh
   fi
 
-  
   install -m 0644 ${WORKDIR}/peridio-cert.pem \
     ${D}/${sysconfdir}/peridiod
 }

--- a/recipes-peridio/peridiod/peridiod_git.bb
+++ b/recipes-peridio/peridiod/peridiod_git.bb
@@ -1,6 +1,6 @@
 require peridiod.inc
 
-PV = "2.4.2"
+PV = "2.5.0"
 
-SRCREV = "78ce12788bcbba2a91cad9cad23dbffdf8427044"
+SRCREV = "ad3041b94dad5e844a1bc91c6333970c56b2e2d2"
 SRCBRANCH = "main"


### PR DESCRIPTION
bump peridiod to v2.5.0. Adds support for remote access tunnels features.
See the [release notes](https://github.com/peridio/peridiod/releases/tag/v2.5.0) for more information. 

Upon merge, I am going to cherry pick this into `kirkstone` and `scarthgap`
